### PR TITLE
Feature: historical win/loss between two teams | Fix: Optionals in StdResponse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ cython_debug/
 
 # JSON 
 *.json
+
+# DS_Store for MacOS
+.DS_Store

--- a/src/apis/historical_win_loss.py
+++ b/src/apis/historical_win_loss.py
@@ -1,0 +1,17 @@
+from src.app.router import BaseRouter
+from src.app.req_res import HistoricalWinLossRequest
+from src.utils.error_handler import ErrorHandler
+
+def include_route(routerobj: BaseRouter) -> None:
+    @routerobj.router.post("/teams/win-loss")
+    def historical_win_loss(request: HistoricalWinLossRequest):
+        try:
+            win_loss = routerobj.service.historical_win_loss(request=request)
+            return ErrorHandler.handle_success(
+                data={
+                    "data" : win_loss
+                },
+                message="win-loss request successful"
+            )
+        except Exception as e:
+            return ErrorHandler.handle_error(e)

--- a/src/app/models.py
+++ b/src/app/models.py
@@ -16,4 +16,18 @@ class PlayerName(BaseModel):
     """
     full_name: str
 
+class TeamCode(BaseModel):
+    
+    """
+    Model for storing a team's NCAA code.
 
+    This model is used to represent a team's NCAA code 
+    as retrieved from a BigQuery result. It is designed to 
+    handle a single player name and is particularly useful 
+    when fetching a list of player names.
+
+    Attributes:
+        team_code (int): The NCAA code that represents the team
+        can be found here: https://stats.ncaa.org/game_upload/team_codes
+    """
+    ncaa_code: int

--- a/src/app/req_res.py
+++ b/src/app/req_res.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 from pydantic import BaseModel
-from .models import PlayerName
+from .models import PlayerName, TeamCode
 
 """ Add req res models here """
 
@@ -60,8 +60,40 @@ class PlayerNameListRespone(BaseModel):
             each representing a player's full name.
     """
     players: List[PlayerName]
+    
+    
+
+class HistoricalWinLossRequest(BaseModel):
+    """
+    Request model for comparing two players.
+
+    This model is used to encapsulate the names of the two players 
+    that will be compared using the PlayerComparisonQuery. It ensures 
+    that the player names are provided in a structured and validated manner.
+
+    Attributes:
+        player1_name (PlayerName): The full name of the first player.
+        player2_name (PlayerName): The full name of the second player.
+    """
+    team1_code: TeamCode
+    team2_code: TeamCode
 
 
+
+class HistoricalWinLossResults(BaseModel):
+    """
+    Data model for player comparison results.
+
+    This model is used to structure the data returned 
+    after running a PlayerComparison BigQuery query. 
+    It facilitates easy access and manipulation of the 
+    comparison data in a structured format.
+    """
+    
+    wins: Optional[int] = None
+    losses: Optional[int] = None
+
+    
 
 class StdResponse(BaseModel):
     message: str

--- a/src/app/req_res.py
+++ b/src/app/req_res.py
@@ -97,8 +97,8 @@ class HistoricalWinLossResults(BaseModel):
 
 class StdResponse(BaseModel):
     message: str
-    error: str | None = None
-    data: dict | None = None
+    error: Optional[str]
+    data: Optional[dict]
     status_code: int
     success: bool
     

--- a/src/app/router.py
+++ b/src/app/router.py
@@ -13,9 +13,10 @@ class BaseRouter:
         return self.router
     
     def include_routes(self) -> APIRouter:
-        from src.apis import fetch_players, compare_players
+        from src.apis import fetch_players, compare_players, historical_win_loss
 
         fetch_players.include_route(self)
         compare_players.include_route(self)
+        historical_win_loss.include_route(self)
 
         return self.router

--- a/src/app/service.py
+++ b/src/app/service.py
@@ -48,8 +48,8 @@ class Service:
             query = HistoricalWinLossQuery(request_obj=request)
             job_config = bigquery.QueryJobConfig(
                 query_parameters=[
-                    bigquery.ScalarQueryParameter("team1_code", "INT", request.team1_code.ncaa_code),
-                     bigquery.ScalarQueryParameter("team2_code", "INT", request.team2_code.ncaa_code)
+                    bigquery.ScalarQueryParameter("team1_code", "INT64", request.team1_code.ncaa_code),
+                     bigquery.ScalarQueryParameter("team2_code", "INT64", request.team2_code.ncaa_code)
                 ]
             )
             result = self.client.execute_query(query=query.get_query(), job_config=job_config)

--- a/src/app/service.py
+++ b/src/app/service.py
@@ -2,6 +2,7 @@ from .req_res import PlayerNameListRespone
 from src.client.configure_bq import ConfigureBigQuery
 from src.queries.fetch_names_query import FetchAllPlayerNamesQuery
 from src.queries.player_compare import PlayerComparisonQuery, PlayerComparisonRequest
+from src.queries.historical_win_loss import HistoricalWinLossQuery, HistoricalWinLossRequest
 from .models import PlayerName
 from .req_res import PlayerComparisonResult
 from google.cloud import bigquery
@@ -42,5 +43,20 @@ class Service:
             raise e 
     
 
+    def historical_win_loss(self, request: HistoricalWinLossRequest):
+        try:
+            query = HistoricalWinLossQuery(request_obj=request)
+            job_config = bigquery.QueryJobConfig(
+                query_parameters=[
+                    bigquery.ScalarQueryParameter("team1_code", "INT", request.team1_code.ncaa_code),
+                     bigquery.ScalarQueryParameter("team2_code", "INT", request.team2_code.ncaa_code)
+                ]
+            )
+            result = self.client.execute_query(query=query.get_query(), job_config=job_config)
+    
+            return [dict(row) for row in result] 
+    
+        except Exception as e :
+            raise e 
         
     

--- a/src/queries/historical_win_loss.py
+++ b/src/queries/historical_win_loss.py
@@ -4,8 +4,8 @@ from src.queries.base_query import BaseQuery
 class HistoricalWinLossQuery(BaseQuery):
     def __init__(self, request_obj : HistoricalWinLossRequest):
         super().__init__()
-        self.team1code : str = request_obj.team1_code.ncaa_code
-        self.team2code : str = request_obj.team2_code.ncaa_code
+        self.team1code : int = request_obj.team1_code.ncaa_code
+        self.team2code : int = request_obj.team2_code.ncaa_code
         self.build_query()
 
     """ this query takes 7.74 MB to execute as tested """
@@ -17,7 +17,7 @@ class HistoricalWinLossQuery(BaseQuery):
         FROM 
             `bigquery-public-data.ncaa_basketball.mbb_historical_teams_games` 
         WHERE 
-            team_code = CAST(@team1_code AS STRING)
+            team_code = CAST(@team1_code AS string)
         AND 
             opp_code = @team2_code
         LIMIT 1000

--- a/src/queries/historical_win_loss.py
+++ b/src/queries/historical_win_loss.py
@@ -1,0 +1,27 @@
+from src.app.req_res import HistoricalWinLossRequest
+from src.queries.base_query import BaseQuery
+
+class HistoricalWinLossQuery(BaseQuery):
+    def __init__(self, request_obj : HistoricalWinLossRequest):
+        super().__init__()
+        self.team1code : str = request_obj.team1_code.ncaa_code
+        self.team2code : str = request_obj.team2_code.ncaa_code
+        self.build_query()
+
+    """ this query takes 7.74 MB to execute as tested """
+    def build_query(self) -> None:
+        self.query = """
+        SELECT 
+            COALESCE(SUM(CASE WHEN win THEN 1 ELSE 0 END)) as wins, 
+            COALESCE(SUM(CASE WHEN win THEN 0 ELSE 1 END)) as losses 
+        FROM 
+            `bigquery-public-data.ncaa_basketball.mbb_historical_teams_games` 
+        WHERE 
+            team_code = CAST(@team1_code AS STRING)
+        AND 
+            opp_code = @team2_code
+        LIMIT 1000
+        """
+
+
+


### PR DESCRIPTION
Gets the wins-losses between two teams. W/L From the perspective of team1. Teams are identified by their NCAA code. Team codes are from the NCAA and can be found at the following site: https://stats.ncaa.org/game_upload/team_codes.

Added Optionals in StdResponse. This can be omitted if nobody else encounters these issues. My `uvicorn main:app --reload` statement was crashing otherwise and indicating that the original section was not valid. I am not sure what the cause of that is.